### PR TITLE
Remove periods from customizing-a-workflow-for-triaging-your-notifications

### DIFF
--- a/content/account-and-profile/managing-subscriptions-and-notifications-on-github/viewing-and-triaging-notifications/customizing-a-workflow-for-triaging-your-notifications.md
+++ b/content/account-and-profile/managing-subscriptions-and-notifications-on-github/viewing-and-triaging-notifications/customizing-a-workflow-for-triaging-your-notifications.md
@@ -27,10 +27,10 @@ For an example workflow of removing notifications that are easy to remove or tri
 Choose which type of notifications are most urgent to review and pick a time to review them that's best for you. You might consider the question "Who am I blocking?"
 
 For example, you may decide to check your notifications in this order in the morning during your daily planning time:
-* Pull requests where your review is requested. (filter by `reason:review-requested`)
-* Events where your username is @mentioned, also called direct mentions. (filter by `reason:mention`)
-* Events where a team you're a member of is @mentioned, also called team mentions. (filter by `reason:team-mention`)
-* CI workflow failures for a specific repository. (filter by `reason:ci-activity` and `repo:owner/repo-name` and ensure you've enabled CI activity notifications for workflow failures in your notification settings)
+* Pull requests where your review is requested (filter by `reason:review-requested`)
+* Events where your username is @mentioned, also called direct mentions (filter by `reason:mention`)
+* Events where a team you're a member of is @mentioned, also called team mentions (filter by `reason:team-mention`)
+* CI workflow failures for a specific repository (filter by `reason:ci-activity` and `repo:owner/repo-name` and ensure you've enabled CI activity notifications for workflow failures in your notification settings)
 
   {% tip %}
 


### PR DESCRIPTION
<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request. By explaining why you're making a change (or linking to an issue) and what changes you've made, we can triage your pull request to the best possible team for review.
-->

### Why:
Removed periods from customizing-a-workflow-for-triaging-your-notifications

Closes: 
Issue #33904, 

<!-- If there's an existing issue for your change, please link to it above.
If there's _not_ an existing issue, please open one first to make it more likely that this update will be accepted: https://github.com/github/docs/issues/new/choose. -->

### What's being changed (if available, include any code snippets, screenshots, or gifs):

<!-- Let us know what you are changing. Share anything that could provide the most context.
If you made changes to the `content` directory, a table will populate in a comment below with links to the preview and current production articles. -->

### Check off the following:

- [ ] I have reviewed my changes in staging, available via the **View deployment** link in this PR's timeline (this link will be available after opening the PR).

  - For content changes, you will also see an automatically generated comment with links directly to pages you've modified. The comment won't appear if your PR only edits files in the `data` directory.
- [ ] For content changes, I have completed the [self-review checklist](https://docs.github.com/en/contributing/collaborating-on-github-docs/self-review-checklist).
